### PR TITLE
Refactor first boot setup

### DIFF
--- a/files/91_openstack_override.cfg-debian
+++ b/files/91_openstack_override.cfg-debian
@@ -12,6 +12,3 @@ users:
   - default
   - name: root
     lock_passwd: true
-bootcmd:
-  - [cloud-init-per, once, unattended-upgrades, systemctl, enable, --now, unattended-upgrades.service]
-  - [cloud-init-per, once, apt-daily-upgrade, systemctl, enable, --now, apt-daily-upgrade.timer]

--- a/files/91_openstack_override.cfg-rhel
+++ b/files/91_openstack_override.cfg-rhel
@@ -12,5 +12,3 @@ users:
   - default
   - name: root
     lock_passwd: true
-bootcmd:
-  - [cloud-init-per, once, dnf-automatic, systemctl, enable, --now, dnf-automatic-install.timer]

--- a/recipes/openstack.rb
+++ b/recipes/openstack.rb
@@ -113,3 +113,10 @@ execute 'rebuild initramfs' do
   live_stream true
   action :nothing
 end
+
+# TODO: Workaround issue with Debian booting on aarch64
+directory '/boot/efi/EFI/boot' if ::File.exist?('/boot/efi/EFI/debian/grubaa64.efi')
+
+remote_file '/boot/efi/EFI/boot/bootaa64.efi' do
+  source 'file:///boot/efi/EFI/debian/grubaa64.efi'
+end if ::File.exist?('/boot/efi/EFI/debian/grubaa64.efi')

--- a/recipes/repos.rb
+++ b/recipes/repos.rb
@@ -355,3 +355,26 @@ elsif platform_family?('debian')
     action :nothing
   end
 end
+
+directory '/usr/local/libexec'
+
+template '/usr/local/libexec/firstboot.sh' do
+  mode '0755'
+end
+
+systemd_unit 'osuosl-firstboot.service' do
+  content <<~EOU
+    [Unit]
+    Description=OSUOSL First Boot script /usr/local/libexec/firstboot.sh
+    After=network-online.target
+    Wants=network-online.target
+
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/local/libexec/firstboot.sh
+
+    [Install]
+    WantedBy=multi-user.target
+  EOU
+  action [:create, :enable]
+end

--- a/templates/firstboot.sh.erb
+++ b/templates/firstboot.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+<% if node['platform_family'] == 'rhel' -%>
+systemctl enable --now dnf-automatic-install.timer
+<% elsif node['platform_family'] == 'debian' -%>
+systemctl unmask apt-daily-upgrade.service apt-daily.service
+systemctl enable --now unattended-upgrades.service apt-daily-upgrade.timer apt-daily-upgrade.service
+<% end -%>
+systemctl disable osuosl-firstboot
+rm -rf /etc/systemd/system/osuosl-firstboot.service
+rm -rf /usr/local/libexec/firstboot.sh
+systemctl daemon-reload

--- a/test/integration/inspec/controls/openstack_spec.rb
+++ b/test/integration/inspec/controls/openstack_spec.rb
@@ -112,13 +112,6 @@ control 'openstack' do
   describe file '/etc/cloud/cloud.cfg.d/91_openstack_override.cfg' do
     its('content') { should match /datasource_list: \['OpenStack'\]/ }
     its('content') { should match %r{metadata_urls: \['http://169.254.169.254'\]} }
-    case os_family
-    when 'debian'
-      its('content') { should match /cloud-init-per, once, unattended-upgrades, systemctl, enable, --now, unattended-upgrades.service/ }
-      its('content') { should match /cloud-init-per, once, apt-daily-upgrade, systemctl, enable, --now, apt-daily-upgrade.timer/ }
-    when 'redhat'
-      its('content') { should match /cloud-init-per, once, dnf-automatic, systemctl, enable, --now, dnf-automatic-install.timer/ }
-    end
   end
 
   %w(


### PR DESCRIPTION
Using cloud-init to finish first boot commands has some issues. Instead let's move this to a self-destructing systemd unit file and script.

This also fixes an issue with the apt-daily-upgrade.timer not working properly by ensuring we unmask the apt-daily.service and apt-daily-upgrade.service units.
